### PR TITLE
ci(travis): specify Node 13 & 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ cache: npm
 node_js:
   - "10"
   - "12"
-  - "node"
+  - "13"
+  - "14"
 
 before_install:
   - npm install --no-save coveralls


### PR DESCRIPTION
specify versions to help with debugging.

Node 13 is retained for now for debugging (ref https://github.com/hexojs/site/pull/1395), to be deprecated in [June 2020](https://github.com/nodejs/Release#release-schedule).